### PR TITLE
SplashScreen: added option to use icon as logo

### DIFF
--- a/Extensions/SplashScreen/SplashScreen.ps1
+++ b/Extensions/SplashScreen/SplashScreen.ps1
@@ -57,6 +57,7 @@ function Invoke-ViewSettings
             <CheckBox Name="CBviewVideoFullscreenMode" Margin="0,10,0,0"/>
             <CheckBox Name="CBcloseSplashScreenFullscreenMode" Margin="0,10,0,0"/>
             <CheckBox Name="CBshowLogoInSplashscreen" Margin="0,20,0,0"/>
+            <CheckBox Name="CBuseIconAsLogo" Margin="0,10,0,0"/>
             <DockPanel Margin="0,10,0,0">
                 <TextBlock Name="TextBlockLogoPosition" DockPanel.Dock="Left" VerticalAlignment="Center"/>
                 <ComboBox Name="ComboBoxLogoPosition" DockPanel.Dock="Left" Width="Auto" MinWidth="150" 
@@ -111,6 +112,7 @@ function Invoke-ViewSettings
 
     $CBshowLogoInSplashscreen.Add_Checked(
     {
+        $CBuseIconAsLogo.IsEnabled = $true
         $TextBlockLogoPosition.IsEnabled = $true
         $ComboBoxLogoPosition.IsEnabled = $true
         $TextBlockLogoVerticalAlignment.IsEnabled = $true
@@ -119,6 +121,7 @@ function Invoke-ViewSettings
 
     $CBshowLogoInSplashscreen.Add_Unchecked(
     {
+        $CBuseIconAsLogo.IsEnabled = $false
         $TextBlockLogoPosition.IsEnabled = $false
         $ComboBoxLogoPosition.IsEnabled = $false
         $TextBlockLogoVerticalAlignment.IsEnabled = $false
@@ -155,6 +158,10 @@ function Invoke-ViewSettings
     $CBshowLogoInSplashscreen.Content = "Add game logo in splashscreen image if available"
     $CBshowLogoInSplashscreen.IsChecked = $true
     $CBshowLogoInSplashscreen.IsChecked = $settings.showLogoInSplashscreen
+
+    $CBuseIconAsLogo.Content = "Use game icon from Metadata as logo"
+    $CBuseIconAsLogo.IsChecked = $false
+    $CBuseIconAsLogo.IsChecked = $settings.useIconAsLogo
 
     $CBuseBlackSplashscreen.Content = "Use black splashscreen instead of the splashscreen image"
     $CBuseBlackSplashscreen.IsChecked = $settings.useBlackSplashscreen
@@ -232,6 +239,7 @@ function Invoke-ViewSettings
         $settings.viewVideoFullscreenMode = $CBviewVideoFullscreenMode.IsChecked
         $settings.closeSplashScreenFullscreenMode = $CBcloseSplashScreenFullscreenMode.IsChecked
         $settings.showLogoInSplashscreen = $CBshowLogoInSplashscreen.IsChecked
+        $settings.useIconAsLogo = $CBuseIconAsLogo.IsChecked
         $settings.logoPosition = $ComboBoxLogoPosition.SelectedValue
         $settings.logoVerticalAlignment = $ComboBoxLogoVerticalAlignment.SelectedValue
         $settings.useBlackSplashscreen = $CBuseBlackSplashscreen.IsChecked
@@ -269,6 +277,7 @@ function Get-Settings
         "viewVideoFullscreenMode" = $true
         "closeSplashScreenFullscreenMode" = $true
         "showLogoInSplashscreen" = $false
+        "useIconAsLogo" = $false
         "logoPosition" = "Center"
         "logoVerticalAlignment" = "Center"
         "useBlackSplashscreen" = $false
@@ -661,7 +670,12 @@ function OnGameStarting
         $logoPath = ""
         if ($settings.showLogoInSplashscreen -eq $true)
         {
-            $logoPath = [System.IO.Path]::Combine($PlayniteApi.Paths.ConfigurationPath, "ExtraMetadata", "games", $game.Id, "Logo.png")
+            if ($settings.useIconAsLogo -eq $true)
+            {
+                $logoPath = $PlayniteApi.Database.GetFullFilePath($game.Icon)
+            } else {
+                $logoPath = [System.IO.Path]::Combine($PlayniteApi.Paths.ConfigurationPath, "ExtraMetadata", "games", $game.Id, "Logo.png")
+            }
         }
 
         @($splashImage, $logoPath, $closeSplashScreenAutomatic, $settings.logoPosition, $settings.logoVerticalAlignment) | ConvertTo-Json | Out-File (Join-Path $env:TEMP -ChildPath "SplashScreen.json")


### PR DESCRIPTION
With the "SGDB Metadata Provider" it is possible to download logos instead of icons in the normal Metadata download.
I personally would like to use those instead of the ones provided by the Extra Metadata Tools so the download happens automatically as i am extraordinary lazy :D
In this PR i added an option in the settings to use the icon image as logo on the splash screen.

I hope i made the changes in the right branch. And thank you for all the great extensions!

Logo in Game Metadata:
![image](https://user-images.githubusercontent.com/87882842/129484070-eb855a82-a97b-4aa5-9bae-0e5f47504f20.png)

New option:
![image](https://user-images.githubusercontent.com/87882842/129484646-2291aea7-b2ff-4bb8-9f93-6b731e5ce7d0.png)
